### PR TITLE
Better Emscripten integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ target_compile_features(glfw-cpp PRIVATE cxx_std_20)
 set_target_properties(glfw-cpp PROPERTIES CXX_EXTENSIONS OFF)
 
 if(EMSCRIPTEN)
+  target_sources(glfw-cpp PRIVATE source/emscripten.cpp)
+
   target_compile_options(glfw-cpp PUBLIC "--use-port=contrib.glfw3")
   target_link_options(glfw-cpp PUBLIC "--use-port=contrib.glfw3")
 else()

--- a/example/source/emscripten/main.cpp
+++ b/example/source/emscripten/main.cpp
@@ -1,6 +1,6 @@
 #include <GLES2/gl2.h>
-#include <GLFW/emscripten_glfw3.h>
 #include <emscripten/emscripten.h>
+#include <glfw_cpp/emscripten.hpp>
 #include <glfw_cpp/glfw_cpp.hpp>
 
 #include <cmath>
@@ -38,11 +38,19 @@ int main()
         println("glfw-cpp [{:-^20}]: {}", to_string(code), msg);
     });
 
-    glfw->apply_hints({ .api = glfw_cpp::api::OpenGLES<true>{ .version_major = 2, .version_minor = 0 } });
+    glfw->apply_hints({
+        .api = glfw_cpp::api::OpenGLES{ 
+            .version_major = 2, 
+            .version_minor = 0, 
+        },
+        .emscripten = {
+            .canvas_selector = "#canvas",
+            .resize_selector = "#canvas-container",
+            .handle_selector = "#canvas-handle",
+        },
+    });
 
-    emscripten::glfw3::SetNextWindowCanvasSelector("#canvas");
-    auto window = glfw->create_window(800, 600, "Hello emscripten from glfw-cpp", nullptr, nullptr);
-    emscripten::glfw3::MakeCanvasResizable(window.handle(), "#canvas-container", "#canvas-handle");
+    auto window = glfw->create_window(800, 600, "Hello emscripten from glfw-cpp");
 
     glfw_cpp::make_current(window.handle());
 
@@ -68,8 +76,8 @@ int main()
                 switch (e.key) {
                 case KC::Q: window.request_close(); break;
                 case KC::F: {
-                    if (not emscripten::glfw3::IsWindowFullscreen(window.handle())) {
-                        emscripten::glfw3::RequestFullscreen(window.handle(), false, true);
+                    if (not glfw_cpp::em::is_window_fullscreen(window.handle())) {
+                        glfw_cpp::em::request_fullscreen(window.handle(), false, true);
                     }
                 } break;
                 default: /* nothing */;

--- a/example/source/emscripten/main.cpp
+++ b/example/source/emscripten/main.cpp
@@ -39,9 +39,9 @@ int main()
     });
 
     glfw->apply_hints({
-        .api = glfw_cpp::api::OpenGLES{ 
-            .version_major = 2, 
-            .version_minor = 0, 
+        .api = glfw_cpp::api::WebGL{
+            .version_major = 2,
+            .version_minor = 0,
         },
         .emscripten = {
             .canvas_selector = "#canvas",

--- a/example/source/emscripten/main.cpp
+++ b/example/source/emscripten/main.cpp
@@ -1,10 +1,11 @@
 #include <GLES2/gl2.h>
 #include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
 #include <glfw_cpp/emscripten.hpp>
 #include <glfw_cpp/glfw_cpp.hpp>
 
 #include <cmath>
-#include <iostream>
+#include <cstdio>
 
 template <typename Fn>
 concept Loop = std::move_constructible<Fn> and requires (Fn fn) {
@@ -27,7 +28,7 @@ void set_main_loop(Fn fn)
 template <typename... Args>
 void println(std::format_string<Args...> fmt, Args&&... args)
 {
-    std::cout << std::format(fmt, std::forward<Args>(args)...) << '\n';
+    std::puts(std::format(fmt, std::forward<Args>(args)...).c_str());
 }
 
 int main()
@@ -78,6 +79,8 @@ int main()
                 case KC::F: {
                     if (not glfw_cpp::em::is_window_fullscreen(window.handle())) {
                         glfw_cpp::em::request_fullscreen(window.handle(), false, true);
+                    } else {
+                        auto ret = emscripten_exit_fullscreen();
                     }
                 } break;
                 default: /* nothing */;

--- a/include/glfw_cpp/constants.hpp
+++ b/include/glfw_cpp/constants.hpp
@@ -12,6 +12,9 @@ namespace glfw_cpp::inline constants
     template <std::integral Int>
     static constexpr auto any_position_v = static_cast<Int>(0x80000000);
     static constexpr auto any_position   = any_position_v<int>;
+
+    // for emscripten
+    static constexpr auto default_canvas_selector = "Module['canvas']";
 }
 
 #endif /* end of include guard: GLFW_CPP_CONSTANTS_HPP */

--- a/include/glfw_cpp/emscripten.hpp
+++ b/include/glfw_cpp/emscripten.hpp
@@ -1,7 +1,6 @@
 #ifndef GLFW_CPP_EMSCRIPTEN_HPP
 #define GLFW_CPP_EMSCRIPTEN_HPP
 
-#include <functional>
 #include <optional>
 #include <string_view>
 

--- a/include/glfw_cpp/emscripten.hpp
+++ b/include/glfw_cpp/emscripten.hpp
@@ -7,11 +7,10 @@
 struct GLFWwindow;
 
 /**
- * NOTE: Function for canvas selector for new window (`emscripten_glfw_set_next_window_canvas_selector`)
+ * @note Function for canvas selector for new window (`emscripten_glfw_set_next_window_canvas_selector`)
  * and funciton for canvas resizing (`emscripten_glfw_make_canvas_resizable`) are not directly wrapped in
  * here. Instead, those functionalities are integrated direclty with hints (see `glfw_cpp::hint::Emscripten`).
  */
-
 namespace glfw_cpp::em
 {
 #if __EMSCRIPTEN__
@@ -58,7 +57,7 @@ namespace glfw_cpp::em
     Result request_fullscreen(GLFWwindow* window, bool lock_pointer, bool resize_canvas);
 
     /**
-     * @brief Get timeout of super + <other> key press event before released.
+     * @brief Get timeout for super + <other> key press event before released event trigger.
      *
      * This code is part of workaround for emscripten: in the case when super key + any other key pressed the
      * up (release) event will never trigger. emscripten-glfw fixes this by adding a timeout for the press
@@ -69,7 +68,7 @@ namespace glfw_cpp::em
     SuperPlusKeyTimeout get_super_plus_key_timeout();
 
     /**
-     * @brief Set timeout for super + <other> key release event workaround.
+     * @brief Set timeout for super + <other> key press event before released event trigger.
      *
      * @param timeout The desired timeout.
      *

--- a/include/glfw_cpp/emscripten.hpp
+++ b/include/glfw_cpp/emscripten.hpp
@@ -1,0 +1,49 @@
+#ifndef GLFW_CPP_EMSCRIPTEN_HPP
+#define GLFW_CPP_EMSCRIPTEN_HPP
+
+#include <functional>
+#include <optional>
+#include <string_view>
+
+struct GLFWwindow;
+
+namespace glfw_cpp::em
+{
+#if __EMSCRIPTEN__
+    // compatible with `EMSCRIPTEN_RESULT`
+    enum class Result : int
+    {
+        Success           = 0,
+        Deferred          = 1,
+        NotSupported      = -1,
+        FailedNotDeferred = -2,
+        InvalidTarget     = -3,
+        UnknownTarget     = -4,
+        InvalidParam      = -5,
+        Failed            = -6,
+        NoData            = -7,
+        TimedOut          = -8,
+
+    };
+
+    struct SuperPlusKeyTimeout
+    {
+        int timeout;           // in ms
+        int repeat_timeout;    // in ms
+    };
+
+    bool is_window_fullscreen(GLFWwindow* window);
+
+    Result request_fullscreen(GLFWwindow* window, bool lock_pointer, bool resize_canvas);
+
+    SuperPlusKeyTimeout get_super_plus_key_timeout();
+
+    void set_super_plus_key_timeout(SuperPlusKeyTimeout timeout);
+
+    void open_url(std::string_view url, std::optional<std::string_view> target = std::nullopt);
+
+    bool is_runtime_platform_apple();
+#endif
+}
+
+#endif /* end of include guard: GLFW_CPP_EMSCRIPTEN_HPP */

--- a/include/glfw_cpp/emscripten.hpp
+++ b/include/glfw_cpp/emscripten.hpp
@@ -6,6 +6,12 @@
 
 struct GLFWwindow;
 
+/**
+ * NOTE: Function for canvas selector for new window (`emscripten_glfw_set_next_window_canvas_selector`)
+ * and funciton for canvas resizing (`emscripten_glfw_make_canvas_resizable`) are not directly wrapped in
+ * here. Instead, those functionalities are integrated direclty with hints (see `glfw_cpp::hint::Emscripten`).
+ */
+
 namespace glfw_cpp::em
 {
 #if __EMSCRIPTEN__
@@ -31,16 +37,62 @@ namespace glfw_cpp::em
         int repeat_timeout;    // in ms
     };
 
+    /**
+     * @brief Check whether window is fullscreen.
+     *
+     * @param window Window handle.
+     */
     bool is_window_fullscreen(GLFWwindow* window);
 
+    /**
+     * @brief Request the window to go fullscreen.
+     *
+     * @param window Window handle to the window that wants to go fullscreen.
+     * @param lock_pointer Whether to lock the pointer.
+     * @param resize_canvas
+     * @return `Result::Success` if there was no issue, or an emscripten error code otherwise.
+     *
+     * @note Due to browser restrictions, this function should only be called from a user generated event
+     * (like a keyboard event or a mouse button press).
+     */
     Result request_fullscreen(GLFWwindow* window, bool lock_pointer, bool resize_canvas);
 
+    /**
+     * @brief Get timeout of super + <other> key press event before released.
+     *
+     * This code is part of workaround for emscripten: in the case when super key + any other key pressed the
+     * up (release) event will never trigger. emscripten-glfw fixes this by adding a timeout for the press
+     * event so that the release event trigger.
+     *
+     * The default value is 525ms for `timeout` and 125ms for `repeat_timeout`.
+     */
     SuperPlusKeyTimeout get_super_plus_key_timeout();
 
+    /**
+     * @brief Set timeout for super + <other> key release event workaround.
+     *
+     * @param timeout The desired timeout.
+     *
+     * This code is part of workaround for emscripten: in the case when super key + any other key pressed the
+     * up (release) event will never trigger. emscripten-glfw fixes this by adding a timeout for the press
+     * event so that the release event trigger.
+     */
     void set_super_plus_key_timeout(SuperPlusKeyTimeout timeout);
 
+    /**
+     * @brief Convenient function to open a url.
+     *
+     * @param url The url to be opened.
+     * @param target A string, without whitespace, specifying the name of the browsing context the resource is
+     * being loaded into.
+     *
+     * @note Check https://developer.mozilla.org/en-US/docs/Web/API/Window/open for valid options for target.
+     */
     void open_url(std::string_view url, std::optional<std::string_view> target = std::nullopt);
 
+    /**
+     * @brief Check if the runtime is running on Apple platform.
+     */
     bool is_runtime_platform_apple();
 #endif
 }

--- a/include/glfw_cpp/instance.hpp
+++ b/include/glfw_cpp/instance.hpp
@@ -71,20 +71,20 @@ namespace glfw_cpp
         };
     }
 
+    /**
+     * The following note is only relevant if you are using glfw-cpp from emscripten.
+     *
+     * @note emscripten-glfw treats the `GLFW_CLIENT_API` value `GLFW_OPENGL_API` and `GLFW_OPENGLES_API` as
+     * the same. If the hint is set to either, the library will create a WebGL context via emscripten html5
+     * API: `emscripten_webgl_create_context()`. To use the hint for OpenGL and OpenGLES then is misleading,
+     * so I decided to add WebGL struct just for this while disabling OpenGL and OpenGLES on Emscripten. Read
+     * the documentation from emscripten-glfw for more detail:
+     * - https://github.com/pongasoft/emscripten-glfw/blob/master/docs/Usage.md#webglopengl-support
+     */
     namespace api
     {
         using helper::meta::may_opt;
         using helper::meta::MayOpt;
-
-        /**
-         * NOTE: emscripten-glfw treats the GLFW_CLIENT_API value GLFW_OPENGL_API and GLFW_OPENGLES_API as the
-         * same. If the hint is set to either, the library will create a WebGL context via emscripten html5
-         * API: emscripten_webgl_create_context(). To use the hint for OpenGL and OpenGLES then is misleading,
-         * so I decided to add WebGL struct just for this while disabling OpenGL and OpenGLES on Emscripten.
-         *
-         * read the documentation from emscripten-glfw for more detail:
-         * - https://github.com/pongasoft/emscripten-glfw/blob/master/docs/Usage.md#webglopengl-support
-         */
 
 #if __EMSCRIPTEN__
         /**
@@ -765,7 +765,7 @@ namespace glfw_cpp
      * @param platform The platform to query.
      * @return True if platform is supported, false otherwise.
      *
-     * @throw error::InvalidValue if `hint::Platform::Any` is passed as argument.
+     * @throw error::InvalidValue if `hint::Platform::Any` or invalid enum value is passed as argument.
      */
     bool platform_supported(hint::Platform platform);
 

--- a/include/glfw_cpp/instance.hpp
+++ b/include/glfw_cpp/instance.hpp
@@ -273,18 +273,27 @@ namespace glfw_cpp
             MayOpt<Opt, const char*> instance_name = may_opt<Opt>("");
         };
 
+        template <bool Opt = true>
+        struct Emscripten
+        {
+            MayOpt<Opt, std::string_view> canvas_selector = default_canvas_selector;
+            MayOpt<Opt, std::string_view> resize_selector = "";    // set to empty string to disable resize
+            MayOpt<Opt, std::string_view> handle_selector = "";    // set to empty string to disable resize
+        };
+
         /**
          * @enum Platform
          * @brief Specifies the platform to use for windowing and input.
          */
         enum class Platform : int
         {
-            Any     = 0x00060000,
-            Win32   = 0x00060001,
-            Cocoa   = 0x00060002,
-            Wayland = 0x00060003,
-            X11     = 0x00060004,
-            Null    = 0x00060005,
+            Any        = 0x00060000,
+            Win32      = 0x00060001,
+            Cocoa      = 0x00060002,
+            Wayland    = 0x00060003,
+            X11        = 0x00060004,
+            Null       = 0x00060005,
+            Emscripten = 0x00060006
         };
 
         /**
@@ -333,6 +342,7 @@ namespace glfw_cpp
         hint::Cocoa<Opt>       cocoa       = {};
         hint::Wayland<Opt>     wayland     = {};
         hint::X11<Opt>         x11         = {};
+        hint::Emscripten<Opt>  emscripten  = {};
     };
 
     using FullHints    = Hints<false>;

--- a/source/emscripten.cpp
+++ b/source/emscripten.cpp
@@ -1,0 +1,43 @@
+#include "glfw_cpp/emscripten.hpp"
+
+#if not __EMSCRIPTEN__
+    #error "Not compiled by emscripten, this should not be built"
+#endif
+
+#define GLFW_INCLUDE_NONE
+#include <GLFW/emscripten_glfw3.h>
+
+namespace glfw_cpp::em
+{
+    bool is_window_fullscreen(GLFWwindow* window)
+    {
+        return emscripten::glfw3::IsWindowFullscreen(window);
+    }
+
+    Result request_fullscreen(GLFWwindow* window, bool lock_pointer, bool resize_canvas)
+    {
+        auto ret = emscripten::glfw3::RequestFullscreen(window, lock_pointer, resize_canvas);
+        return static_cast<Result>(ret);
+    }
+
+    SuperPlusKeyTimeout get_super_plus_key_timeout()
+    {
+        auto [timeout, repeat_timeout] = emscripten::glfw3::GetSuperPlusKeyTimeouts();
+        return { timeout, repeat_timeout };
+    }
+
+    void set_super_plus_key_timeout(SuperPlusKeyTimeout timeout)
+    {
+        emscripten::glfw3::SetSuperPlusKeyTimeouts(timeout.timeout, timeout.repeat_timeout);
+    }
+
+    void open_url(std::string_view url, std::optional<std::string_view> target)
+    {
+        emscripten::glfw3::OpenURL(url, target);
+    }
+
+    bool is_runtime_platform_apple()
+    {
+        return emscripten::glfw3::IsRuntimePlatformApple();
+    }
+}

--- a/source/emscripten_ctx.hpp
+++ b/source/emscripten_ctx.hpp
@@ -1,0 +1,38 @@
+#ifndef GLFW_CPP_EMSCRIPTEN_CTX_HPP
+#define GLFW_CPP_EMSCRIPTEN_CTX_HPP
+
+#include "glfw_cpp/constants.hpp"
+
+#include <string>
+#include <string_view>
+
+namespace glfw_cpp
+{
+    class EmscriptenCtx
+    {
+    public:
+        static void set_canvas_selector(std::string_view selector) { instance().canvas_selector = selector; }
+        static std::string_view get_canvas_selector() { return instance().canvas_selector; }
+
+        static void set_resize_selector(std::string_view selector) { instance().resize_selector = selector; }
+        static std::string_view get_resize_selector() { return instance().resize_selector; }
+
+        static void set_handle_selector(std::string_view selector) { instance().handle_selector = selector; }
+        static std::string_view get_handle_selector() { return instance().handle_selector; }
+
+        static void reset() { instance() = {}; }
+
+    private:
+        static EmscriptenCtx& instance()
+        {
+            static auto instance = EmscriptenCtx{};
+            return instance;
+        }
+
+        std::string canvas_selector = default_canvas_selector;
+        std::string resize_selector = {};
+        std::string handle_selector = {};
+    };
+}
+
+#endif    // GLFW_CPP_EMSCRIPTEN_CTX_HPP

--- a/source/emscripten_ctx.hpp
+++ b/source/emscripten_ctx.hpp
@@ -6,32 +6,39 @@
 #include <string>
 #include <string_view>
 
+namespace
+{
+    std::optional<std::string> make_opt(const char* str)
+    {
+        return str ? std::optional<std::string>{ str } : std::nullopt;
+    }
+}
+
 namespace glfw_cpp
 {
     class EmscriptenCtx
     {
     public:
-        static void set_canvas_selector(std::string_view selector) { instance().canvas_selector = selector; }
-        static std::string_view get_canvas_selector() { return instance().canvas_selector; }
+        static std::string_view                get_canvas_selector() { return get().canvas_selector; }
+        static std::optional<std::string_view> get_resize_selector() { return get().resize_selector; }
+        static std::optional<std::string_view> get_handle_selector() { return get().handle_selector; }
 
-        static void set_resize_selector(std::string_view selector) { instance().resize_selector = selector; }
-        static std::string_view get_resize_selector() { return instance().resize_selector; }
+        static void set_canvas_selector(const char* s) { get().canvas_selector = s ? s : ""; }
+        static void set_resize_selector(const char* s) { get().resize_selector = make_opt(s); }
+        static void set_handle_selector(const char* s) { get().handle_selector = make_opt(s); }
 
-        static void set_handle_selector(std::string_view selector) { instance().handle_selector = selector; }
-        static std::string_view get_handle_selector() { return instance().handle_selector; }
-
-        static void reset() { instance() = {}; }
+        static void reset() { get() = {}; }
 
     private:
-        static EmscriptenCtx& instance()
+        static EmscriptenCtx& get()
         {
             static auto instance = EmscriptenCtx{};
             return instance;
         }
 
-        std::string canvas_selector = default_canvas_selector;
-        std::string resize_selector = {};
-        std::string handle_selector = {};
+        std::string                canvas_selector = default_canvas_selector;
+        std::optional<std::string> resize_selector = std::nullopt;
+        std::optional<std::string> handle_selector = std::nullopt;
     };
 }
 

--- a/source/emscripten_ctx.hpp
+++ b/source/emscripten_ctx.hpp
@@ -19,13 +19,16 @@ namespace glfw_cpp
     class EmscriptenCtx
     {
     public:
-        static std::string_view                get_canvas_selector() { return get().canvas_selector; }
-        static std::optional<std::string_view> get_resize_selector() { return get().resize_selector; }
-        static std::optional<std::string_view> get_handle_selector() { return get().handle_selector; }
+        static void set_has_context(bool value) { get().m_has_context = value; }
+        static bool get_has_context() { return get().m_has_context; }
 
-        static void set_canvas_selector(const char* s) { get().canvas_selector = s ? s : ""; }
-        static void set_resize_selector(const char* s) { get().resize_selector = make_opt(s); }
-        static void set_handle_selector(const char* s) { get().handle_selector = make_opt(s); }
+        static std::string_view                get_canvas_selector() { return get().m_canvas_selector; }
+        static std::optional<std::string_view> get_resize_selector() { return get().m_resize_selector; }
+        static std::optional<std::string_view> get_handle_selector() { return get().m_handle_selector; }
+
+        static void set_canvas_selector(const char* s) { get().m_canvas_selector = s ? s : ""; }
+        static void set_resize_selector(const char* s) { get().m_resize_selector = make_opt(s); }
+        static void set_handle_selector(const char* s) { get().m_handle_selector = make_opt(s); }
 
         static void reset() { get() = {}; }
 
@@ -36,9 +39,13 @@ namespace glfw_cpp
             return instance;
         }
 
-        std::string                canvas_selector = default_canvas_selector;
-        std::optional<std::string> resize_selector = std::nullopt;
-        std::optional<std::string> handle_selector = std::nullopt;
+        // I need to cache to see whether the currently created window has context since there is no way to
+        // get it from emscripten-glfw
+        bool m_has_context = true;
+
+        std::string                m_canvas_selector = default_canvas_selector;
+        std::optional<std::string> m_resize_selector = std::nullopt;
+        std::optional<std::string> m_handle_selector = std::nullopt;
     };
 }
 

--- a/source/instance.cpp
+++ b/source/instance.cpp
@@ -111,8 +111,8 @@ namespace
         using Ctx = glfw_cpp::EmscriptenCtx;
 
         auto set_selector = util::VisitOverloaded{
-            [](std::optional<std::string_view> s, auto fn) { s ? fn(*s) : void(); },
-            [](std::string_view s, auto fn) { fn(s); },
+            [](std::optional<const char*> s, auto fn) { s ? fn(*s) : void(); },
+            [](const char* s, auto fn) { fn(s); },
         };
 
         set_selector(em.canvas_selector, &Ctx::set_canvas_selector);
@@ -559,11 +559,10 @@ namespace glfw_cpp
 #if __EMSCRIPTEN__
         auto resize_selector = EmscriptenCtx::get_resize_selector();
         auto handle_selector = EmscriptenCtx::get_handle_selector();
-        emscripten::glfw3::MakeCanvasResizable(
-            handle,
-            resize_selector,
-            handle_selector.empty() ? std::nullopt : std::optional<std::string_view>{ handle_selector }
-        );
+
+        if (resize_selector) {
+            emscripten::glfw3::MakeCanvasResizable(handle, *resize_selector, handle_selector);
+        }
 #endif
 
         return Window{ handle, std::move(properties), std::move(attributes) };

--- a/source/instance.cpp
+++ b/source/instance.cpp
@@ -126,6 +126,8 @@ namespace
         set_selector(em.canvas_selector, &Ctx::set_canvas_selector);
         set_selector(em.resize_selector, &Ctx::set_resize_selector);
         set_selector(em.handle_selector, &Ctx::set_handle_selector);
+
+        Ctx::set_has_context(not api.template is<glfw_cpp::api::NoApi>());
 #endif
     }
 }

--- a/source/instance.cpp
+++ b/source/instance.cpp
@@ -561,7 +561,11 @@ namespace glfw_cpp
         auto handle_selector = EmscriptenCtx::get_handle_selector();
 
         if (resize_selector) {
-            emscripten::glfw3::MakeCanvasResizable(handle, *resize_selector, handle_selector);
+            auto ret = emscripten::glfw3::MakeCanvasResizable(handle, *resize_selector, handle_selector);
+            if (ret != EMSCRIPTEN_RESULT_SUCCESS) {
+                auto msg = std::format("MakeCanvasResizable failed: {}", ret);
+                throw error::PlatformError{ msg.c_str() };
+            }
         }
 #endif
 

--- a/source/instance.cpp
+++ b/source/instance.cpp
@@ -26,6 +26,13 @@ namespace
 
         // context
         api.visit(util::VisitOverloaded{
+#if __EMSCRIPTEN__
+            [&](const glfw_cpp::api::WebGL<Opt>& api) {
+                glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
+                window_hint(GLFW_CONTEXT_VERSION_MAJOR, api.version_major);
+                window_hint(GLFW_CONTEXT_VERSION_MINOR, api.version_minor);
+            },
+#else
             [&](const glfw_cpp::api::OpenGL<Opt>& api) {
                 glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
                 window_hint(GLFW_CONTEXT_VERSION_MAJOR, api.version_major);
@@ -54,6 +61,7 @@ namespace
                 window_hint(GLFW_CONTEXT_DEBUG, api.debug);
                 window_hint(GLFW_CONTEXT_NO_ERROR, api.no_error);
             },
+#endif
             [](const glfw_cpp::api::NoApi&) {
                 glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);    //
             },

--- a/source/window.cpp
+++ b/source/window.cpp
@@ -13,13 +13,21 @@
 #include <mutex>
 #include <utility>
 
+#if __EMSCRIPTEN__
+    #include "emscripten_ctx.hpp"
+#endif
+
 namespace glfw_cpp
 {
     Window::Window(Handle handle, Properties&& properties, Attributes&& attributes)
         : m_handle{ handle }
         , m_properties{ std::move(properties) }
         , m_attributes{ std::move(attributes) }
+#if __EMSCRIPTEN__
+        , m_has_context{ EmscriptenCtx::get_has_context() }
+#else
         , m_has_context{ glfwGetWindowAttrib(handle, GLFW_CLIENT_API) != GLFW_NO_API }
+#endif
     {
         glfwSetWindowUserPointer(m_handle, this);
     }


### PR DESCRIPTION
As my goal for creating this library is to eliminate pollution to the global namespace by not requiring including the `<GLFW/glfw3.h>` header directly (or indirectly), I attempt to wrap `emscripten-glfw` extension functions. While at it I also attempt to integrate emscripten support by moving window-related extension functions into hints.

- Add `emscripten-glfw` extension functions into new header: `"glfw_cpp/emscripten.hpp"`.
- Add platform hint and window hints for Emscripten.
- Add `WebGL` hint to better mirror the graphics backend used in Emscripten.
- Fix client API attribute acquisition on Emscripten.